### PR TITLE
improve lmcache manifests: pin openai, startupProbe, clearer test output

### DIFF
--- a/manifests/500-lmcache/cpu-ram-offloading/lmcache-cpu-ram-configmap.yaml
+++ b/manifests/500-lmcache/cpu-ram-offloading/lmcache-cpu-ram-configmap.yaml
@@ -5,8 +5,15 @@ metadata:
 data:
   query-twice.py: |
     import time
+    import sys
     from openai import OpenAI
     from transformers import AutoTokenizer
+    
+    # Number of chars of the model's streaming response to display as a preview.
+    # The full response is still collected (used for length reporting) but only
+    # the first PREVIEW_CHARS characters are streamed to stdout to keep output
+    # readable and focused on the cache timing metrics.
+    PREVIEW_CHARS = 80
     
     client = OpenAI(
         api_key="dummy-key",
@@ -38,12 +45,18 @@ data:
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")
     question = "Summarize the key concepts in 2 sentences."
     
-    def query_and_measure_ttft(context, label):
+    def query_and_measure_ttft(context, label, description):
         prompt = f"{context}\n\n{question}"
-        print(f"Number of tokens in {label} prompt: {len(tokenizer.encode(prompt))}")
+        n_tokens = len(tokenizer.encode(prompt))
+        print(f"\n=== {label} request: {description} ===")
+        print(f"Sending {n_tokens:,}-token prompt to vLLM (model streaming response):")
+        sys.stdout.write("  Response preview: ")
+        sys.stdout.flush()
     
         start = time.perf_counter()
         ttft = None
+        full_response_chars = 0
+        preview_chars_printed = 0
     
         chat_completion = client.chat.completions.create(
             messages=[{"role": "user", "content": prompt}],
@@ -57,20 +70,52 @@ data:
             if chunk_message is not None:
                 if ttft is None:
                     ttft = time.perf_counter()
-                print(chunk_message, end="", flush=True)
+                full_response_chars += len(chunk_message)
+                # Print only the first PREVIEW_CHARS chars to keep output tidy.
+                if preview_chars_printed < PREVIEW_CHARS:
+                    remaining = PREVIEW_CHARS - preview_chars_printed
+                    visible = chunk_message[:remaining]
+                    sys.stdout.write(visible)
+                    sys.stdout.flush()
+                    preview_chars_printed += len(visible)
     
-        print("\n")
+        if full_response_chars > PREVIEW_CHARS:
+            sys.stdout.write(f"...\n  [response truncated - full length: {full_response_chars} chars]\n")
+        else:
+            sys.stdout.write("\n")
+        sys.stdout.flush()
         return ttft - start
     
-    print("Querying vLLM server with cold LMCache CPU Offload")
-    cold_ttft = query_and_measure_ttft(cold_context, "cold")
-    print(f"Cold TTFT: {cold_ttft:.3f} seconds")
+    print("=" * 60)
+    print("LMCache L1 (CPU RAM) Cache Test")
+    print("=" * 60)
+    print("Sends two requests with 90% prompt overlap.")
+    print("Cold request populates the L1 cache; warm request should hit L1")
+    print("and return faster (lower TTFT).")
     
-    print("\nQuerying vLLM server with warm LMCache CPU Offload (90% same content)")
-    warm_ttft = query_and_measure_ttft(warm_context, "warm")
-    print(f"Warm TTFT: {warm_ttft:.3f} seconds")
+    cold_ttft = query_and_measure_ttft(
+        cold_context,
+        "Cold",
+        "LMCache empty, GPU computes all tokens",
+    )
+    print(f"[OK] Cold TTFT: {cold_ttft:.3f}s (L1 cache now populated with prompt's KV tensors)")
     
-    print(f"\nTTFT Improvement: {(cold_ttft - warm_ttft):.3f} seconds ({(cold_ttft/warm_ttft):.1f}x faster)")
+    warm_ttft = query_and_measure_ttft(
+        warm_context,
+        "Warm",
+        "same 90% content, LMCache L1 should serve the matching prefix",
+    )
+    print(f"[OK] Warm TTFT: {warm_ttft:.3f}s (GPU only computed the new 10% tail)")
+    
+    speedup = cold_ttft / warm_ttft if warm_ttft > 0 else 0
+    improvement = cold_ttft - warm_ttft
+    print()
+    print("-" * 60)
+    print(f"TTFT Improvement: {improvement:.3f}s ({speedup:.1f}x faster)")
+    print("Why: cold had to compute KV tensors for all tokens in the prompt;")
+    print("warm served ~90% from LMCache L1 CPU RAM, so the GPU only had to")
+    print("compute the new ~10% (tail bytes + question) from scratch.")
+    print("-" * 60)
     
   python-docs.txt: |
     

--- a/manifests/500-lmcache/cpu-ram-offloading/lmcache-cpu-ram-pod.yaml
+++ b/manifests/500-lmcache/cpu-ram-offloading/lmcache-cpu-ram-pod.yaml
@@ -22,7 +22,7 @@ spec:
     args:
     - |
       # LMCache should be pre-installed in this AWS DLC vllm image
-      python3 -c "import lmcache; print('lmcache version:', lmcache.__version__)" || pip install --no-cache-dir lmcache==0.3.8 openai
+      python3 -c "import lmcache; print('lmcache version:', lmcache.__version__)" || pip install --no-cache-dir lmcache==0.3.8 openai==1.58.1
 
       # Start vllm with LMCache CPU RAM (L1) offloading
       python3 -m vllm.entrypoints.openai.api_server \
@@ -76,11 +76,21 @@ spec:
         cpu: 6
         memory: 32Gi
         nvidia.com/gpu: 1
+    # startupProbe gates the other probes — readiness/liveness only start once
+    # this succeeds. Allows up to 5 minutes for slow startup (image pull,
+    # S3 model download, CUDA init, LMCache init) without holding the pod
+    # artificially "NotReady" after /health is actually responding.
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 60
     readinessProbe:
       httpGet:
         path: /health
         port: 8080
-      initialDelaySeconds: 60
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 3
@@ -88,7 +98,6 @@ spec:
       httpGet:
         path: /health
         port: 8080
-      initialDelaySeconds: 120
       periodSeconds: 30
       timeoutSeconds: 10
       failureThreshold: 3

--- a/manifests/500-lmcache/remote-cache-sharing-with-valkey/lmcache-valkey-configmap.yaml
+++ b/manifests/500-lmcache/remote-cache-sharing-with-valkey/lmcache-valkey-configmap.yaml
@@ -5,8 +5,15 @@ metadata:
 data:
   query-twice.py: |
     import time
+    import sys
     from openai import OpenAI
     from transformers import AutoTokenizer
+    
+    # Number of chars of the model's streaming response to display as a preview.
+    # The full response is still collected (used for length reporting) but only
+    # the first PREVIEW_CHARS characters are streamed to stdout to keep output
+    # readable and focused on the cache timing metrics.
+    PREVIEW_CHARS = 80
     
     client = OpenAI(
         api_key="dummy-key",
@@ -38,12 +45,18 @@ data:
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")
     question = "Summarize the key concepts in 2 sentences."
     
-    def query_and_measure_ttft(context, label):
+    def query_and_measure_ttft(context, label, description):
         prompt = f"{context}\n\n{question}"
-        print(f"Number of tokens in {label} prompt: {len(tokenizer.encode(prompt))}")
+        n_tokens = len(tokenizer.encode(prompt))
+        print(f"\n=== {label} request: {description} ===")
+        print(f"Sending {n_tokens:,}-token prompt to vLLM (model streaming response):")
+        sys.stdout.write("  Response preview: ")
+        sys.stdout.flush()
     
         start = time.perf_counter()
         ttft = None
+        full_response_chars = 0
+        preview_chars_printed = 0
     
         chat_completion = client.chat.completions.create(
             messages=[{"role": "user", "content": prompt}],
@@ -57,20 +70,54 @@ data:
             if chunk_message is not None:
                 if ttft is None:
                     ttft = time.perf_counter()
-                print(chunk_message, end="", flush=True)
+                full_response_chars += len(chunk_message)
+                # Print only the first PREVIEW_CHARS chars to keep output tidy.
+                if preview_chars_printed < PREVIEW_CHARS:
+                    remaining = PREVIEW_CHARS - preview_chars_printed
+                    visible = chunk_message[:remaining]
+                    sys.stdout.write(visible)
+                    sys.stdout.flush()
+                    preview_chars_printed += len(visible)
     
-        print("\n")
+        if full_response_chars > PREVIEW_CHARS:
+            sys.stdout.write(f"...\n  [response truncated - full length: {full_response_chars} chars]\n")
+        else:
+            sys.stdout.write("\n")
+        sys.stdout.flush()
         return ttft - start
     
-    print("Querying vLLM server with cold LMCache CPU Offload")
-    cold_ttft = query_and_measure_ttft(cold_context, "cold")
-    print(f"Cold TTFT: {cold_ttft:.3f} seconds")
+    print("=" * 60)
+    print("LMCache L1 (CPU RAM) + L2 (Valkey Remote) Cache Test")
+    print("=" * 60)
+    print("Sends two requests with 90% prompt overlap.")
+    print("Cold request writes KV tensors to BOTH L1 (local CPU RAM) and L2")
+    print("(Valkey, shared across pods) in parallel. Warm request serves the")
+    print("matching prefix from LMCache (L1 first, falling back to L2 on miss).")
     
-    print("\nQuerying vLLM server with warm LMCache CPU Offload (90% same content)")
-    warm_ttft = query_and_measure_ttft(warm_context, "warm")
-    print(f"Warm TTFT: {warm_ttft:.3f} seconds")
+    cold_ttft = query_and_measure_ttft(
+        cold_context,
+        "Cold",
+        "LMCache empty on this pod, GPU computes all tokens",
+    )
+    print(f"[OK] Cold TTFT: {cold_ttft:.3f}s (KV tensors written to L1 and L2 in parallel)")
     
-    print(f"\nTTFT Improvement: {(cold_ttft - warm_ttft):.3f} seconds ({(cold_ttft/warm_ttft):.1f}x faster)")
+    warm_ttft = query_and_measure_ttft(
+        warm_context,
+        "Warm",
+        "same 90% content, LMCache should serve the matching prefix",
+    )
+    print(f"[OK] Warm TTFT: {warm_ttft:.3f}s (GPU only computed the new 10% tail)")
+    
+    speedup = cold_ttft / warm_ttft if warm_ttft > 0 else 0
+    improvement = cold_ttft - warm_ttft
+    print()
+    print("-" * 60)
+    print(f"TTFT Improvement: {improvement:.3f}s ({speedup:.1f}x faster)")
+    print("Why: cold had to compute KV tensors for all tokens in the prompt;")
+    print("warm served ~90% from LMCache (L1 on this same pod, or L2/Valkey")
+    print("for a freshly-deployed pod), so the GPU only had to compute the")
+    print("new ~10% (tail bytes + question) from scratch.")
+    print("-" * 60)
     
   python-docs.txt: |
     

--- a/manifests/500-lmcache/remote-cache-sharing-with-valkey/lmcache-valkey-pod.yaml
+++ b/manifests/500-lmcache/remote-cache-sharing-with-valkey/lmcache-valkey-pod.yaml
@@ -22,7 +22,7 @@ spec:
     args:
     - |
       # LMCache should be pre-installed in this AWS DLC vllm image
-      python3 -c "import lmcache; print('lmcache version:', lmcache.__version__)" || pip install --no-cache-dir lmcache==0.3.8 openai
+      python3 -c "import lmcache; print('lmcache version:', lmcache.__version__)" || pip install --no-cache-dir lmcache==0.3.8 openai==1.58.1
 
       # Start vllm with LMCache L1 (CPU RAM) + L2 (Valkey remote) offloading
       python3 -m vllm.entrypoints.openai.api_server \
@@ -84,11 +84,21 @@ spec:
         cpu: 6
         memory: 32Gi
         nvidia.com/gpu: 1
+    # startupProbe gates the other probes — readiness/liveness only start once
+    # this succeeds. Allows up to 5 minutes for slow startup (image pull,
+    # S3 model download, CUDA init, LMCache init) without holding the pod
+    # artificially "NotReady" after /health is actually responding.
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 60
     readinessProbe:
       httpGet:
         path: /health
         port: 8080
-      initialDelaySeconds: 60
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 3
@@ -96,7 +106,6 @@ spec:
       httpGet:
         path: /health
         port: 8080
-      initialDelaySeconds: 120
       periodSeconds: 30
       timeoutSeconds: 10
       failureThreshold: 3


### PR DESCRIPTION
Changes to pod manifests (both cpu-ram-offloading and remote-cache-sharing-with-valkey):
- Pin openai==1.58.1 (was unpinned; broke reproducibility across installs)
- Replace readiness/liveness initialDelaySeconds with startupProbe (periodSeconds=5, failureThreshold=60 -> 5 min grace for slow startup)
- Pod transitions to Ready as soon as /health returns 200, not after a fixed 60s wait; saves ~20-40s per pod startup

Changes to query-twice.py in both configmaps:
- Add clear section headers explaining cold vs warm request intent
- Truncate model response to 80-char preview (full length reported)
- Add concluding block explaining what the TTFT numbers mean and why
- Fix copy-paste bug: valkey script now says 'LMCache L1 (CPU RAM) + L2 (Valkey Remote) Cache Test' instead of 'LMCache CPU Offload'

Addresses reviewer feedback that the raw streaming model output (random Python os module summary) was confusing mid-script without context, and that the pod took a fixed 60s before probing.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
