### PR TITLE
fix(grafana): repair broken vLLM Time Per Output Token panels

### DIFF
--- a/terraform/grafana-dashboards/vllm-dashboard.json
+++ b/terraform/grafana-dashboards/vllm-dashboard.json
@@ -290,9 +290,9 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "editorMode": "builder",
-          "expr": "vllm:time_per_output_token_seconds_count",
-          "instant": true,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_time_per_output_token_seconds_sum[5m]) / rate(vllm:request_time_per_output_token_seconds_count[5m])",
+          "instant": false,
           "key": "Q-4f2fc92a-5504-44f5-98c2-707f8123b677-0",
           "range": true,
           "refId": "A"

--- a/terraform/grafana-dashboards/vllm-ray-dashboard.json
+++ b/terraform/grafana-dashboards/vllm-ray-dashboard.json
@@ -35,11 +35,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, rate(vllm:time_per_output_token_seconds_bucket[5m]))",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket[5m])))",
           "legendFormat": "Time per output token p50"
         },
         {
-          "expr": "histogram_quantile(0.95, rate(vllm:time_per_output_token_seconds_bucket[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket[5m])))",
           "legendFormat": "Time per output token p95"
         }
       ],


### PR DESCRIPTION
## Problem

The "vLLM Time Per Output Token" panels in both `terraform/grafana-dashboards/vllm-dashboard.json` and `terraform/grafana-dashboards/vllm-ray-dashboard.json` are permanently empty when the dashboards are deployed against current vLLM versions, even with active inference traffic.

## Root cause

The dashboards query `vllm:time_per_output_token_seconds`, which was deprecated and replaced by two new metrics in vLLM 0.11:

- vLLM PR [#24110](https://github.com/vllm-project/vllm/pull/24110) introduced `vllm:inter_token_latency_seconds` (recorded per generated token — iteration-level, the original semantic) and flagged the old TPOT metric as deprecated.
- vLLM PR [#24015](https://github.com/vllm-project/vllm/pull/24015) introduced `vllm:request_time_per_output_token_seconds` (per-request rollup, recorded once per finished request).
- Per vLLM's deprecation policy (deprecated → hidden → removed), `vllm:time_per_output_token_seconds` is hidden in 0.12 unless `--show-hidden-metrics-for-version=0.11` is passed, and removed in 0.13.

The workshop ships current vLLM images that no longer expose the old metric name by default, so the panels stay empty. Surrounding panels keep working because they query different metrics that weren't renamed.

A second issue in `vllm-dashboard.json`: the panel's query was the raw counter `vllm:time_per_output_token_seconds_count` with both `instant: true` and `range: true` set — invalid for a timeseries panel — and it would have produced a monotonically-increasing counter line, not a TPOT visualization, even with the old metric.

## Fix

**`vllm-ray-dashboard.json`:**

- Switch p50/p95 expressions to `vllm:inter_token_latency_seconds_bucket` (iteration-level, matches the panel's intent and populates on every generated token).
- Add `sum by (le)` for safe aggregation across multiple replicas.

**`vllm-dashboard.json`:**

- Replace the broken counter query with a rate-based average: `rate(vllm:request_time_per_output_token_seconds_sum[5m]) / rate(vllm:request_time_per_output_token_seconds_count[5m])`
- Drop `instant: true` (timeseries panels must be range-only).
- Switch editor mode from builder to code to match the new expression.